### PR TITLE
fix(login): url-encode password to send correct request's body

### DIFF
--- a/src/lib/twitter-login.js
+++ b/src/lib/twitter-login.js
@@ -70,7 +70,7 @@ const loginWithAuthToken = (
   TWITTER_KDT
 ) => {
   return authToken => {
-    const formData = `session%5Busername_or_email%5D=${TWITTER_USERNAME}&session%5Bpassword%5D=${TWITTER_PASSWORD}&remember_me=1&return_to_ssl=true&scribe_log=&redirect_after_login=%2F&authenticity_token=${authToken}`
+    const formData = `session%5Busername_or_email%5D=${TWITTER_USERNAME}&session%5Bpassword%5D=${encodeURIComponent(TWITTER_PASSWORD)}&remember_me=1&return_to_ssl=true&scribe_log=&redirect_after_login=%2F&authenticity_token=${authToken}`
     return fetch('https://twitter.com/sessions', {
       method: 'POST',
       redirect: 'manual',


### PR DESCRIPTION
Otherwise the login request will fail on complex passwords (e.g:
`dàç"[è-9(/8Z7@s&`)

Note: no need to urlEncode the login since it should not contains
any character needing to be urlEncoding